### PR TITLE
Fix outdated docs for Route Identifiers

### DIFF
--- a/content/docs/basics/routing.md
+++ b/content/docs/basics/routing.md
@@ -264,14 +264,14 @@ router.delete('users/:id', () => {}).as('users.delete')
 You can now construct URLs using the route name within your templates or using the URL builder.
 
 ```ts
-const url = router.builder().make('users.delete', [user.id])
+const url = router.builder().params({ id: user.id }).make('users.delete')
 ```
 
 ```edge
 <form
   method='POST'
   action="{{
-    route('users.delete', [user.id], { formAction: 'delete' })
+    route('users.delete', { id: user.id }, { qs: { formAction: 'delete' } })
   }}"
 ></form>
 ```


### PR DESCRIPTION
This used the previous syntax for URL Builder still, as noted in discord: https://discord.com/channels/423256550564691970/423256550564691972/1264631617926729758

I think this is correct now, though I do note you can still write:

```
  route('users.delete', [ user.id ], { qs: { formAction: 'delete' } })
```

I assume `formAction` is meant to be in the querystring, since `MakeUrlOptions` doesn't have a `formAction` property: https://github.com/adonisjs/http-server/blob/ec7b797ff1d209e26c3dee36602d42f88ddf7b31/src/types/route.ts#L210

And under the hood `router.makeUrl(...)` is being used: https://github.com/adonisjs/core/blob/develop/providers/edge_provider.ts#L68